### PR TITLE
Setup CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ jobs:
           name: Install dependencies
           command: pip install requirements_test.txt
       - run:
-          - name: Run tests
-          - tox
+          name: Run tests
+          command: tox
 workflows:
   version: 2
   validate-pr:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+---
+version: 2.1
+jobs:
+  unittests:
+    resource_class: xlarge
+    working_directory: ~/instawork
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - run:
+          name: Install dependencies
+          command: pip install requirements_test.txt
+      - run:
+          - name: Run tests
+          - tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
     docker:
       - image: circleci/python:3.6
     steps:
+      - checkout
       - run:
           name: Install dependencies
           command: pip install -r requirements_test.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - run:
           name: Install dependencies
-          command: pip install requirements_test.txt
+          command: pip install -r requirements_test.txt
       - run:
           name: Run tests
           command: tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,8 @@ jobs:
       - run:
           - name: Run tests
           - tox
+workflows:
+  version: 2
+  validate-pr:
+    jobs:
+      - unittests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 version: 2.1
 jobs:
-  unittests:
+  unittests-python36:
     resource_class: xlarge
     working_directory: ~/django-admin-fast-search
     docker:
@@ -12,10 +12,39 @@ jobs:
           name: Install dependencies
           command: pip install -r requirements_test.txt
       - run:
-          name: Run tests
-          command: tox
+          name: Run tests on Python 3.6
+          command: tox -e py36-django-22,py36-django-30,py36-django-31,py36-django-32
+  unittests-python37:
+    resource_class: xlarge
+    working_directory: ~/django-admin-fast-search
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: pip install -r requirements_test.txt
+      - run:
+          name: Run tests on Python 3.7
+          command: tox -e py37-django-22,py37-django-30,py37-django-31,py37-django-32
+  unittests-python38:
+    resource_class: xlarge
+    working_directory: ~/django-admin-fast-search
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: pip install -r requirements_test.txt
+      - run:
+          name: Run tests on Python 3.8
+          command: tox -e py38-django-22,py38-django-30,py38-django-31,py38-django-32
+
 workflows:
   version: 2
   validate-pr:
     jobs:
-      - unittests
+      - unittests-python36
+      - unittests-python37
+      - unittests-python38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   unittests:
     resource_class: xlarge
-    working_directory: ~/instawork
+    working_directory: ~/django-admin-fast-search
     docker:
       - image: circleci/python:3.6
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 jobs:
   unittests-python36:
-    resource_class: xlarge
+    resource_class: small
     working_directory: ~/django-admin-fast-search
     docker:
       - image: circleci/python:3.6
@@ -15,7 +15,7 @@ jobs:
           name: Run tests on Python 3.6
           command: tox -e py36-django-22,py36-django-30,py36-django-31,py36-django-32
   unittests-python37:
-    resource_class: xlarge
+    resource_class: small
     working_directory: ~/django-admin-fast-search
     docker:
       - image: circleci/python:3.7
@@ -28,7 +28,7 @@ jobs:
           name: Run tests on Python 3.7
           command: tox -e py37-django-22,py37-django-30,py37-django-31,py37-django-32
   unittests-python38:
-    resource_class: xlarge
+    resource_class: small
     working_directory: ~/django-admin-fast-search
     docker:
       - image: circleci/python:3.8

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include requirements.txt
 recursive-include django_admin_fast_search *.html *.png *.gif *js *.css *jpg *jpeg *svg *py

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,6 +6,5 @@ codecov>=2.0.0
 
 
 # Additional test requirements go here
-django==2.2
 factory_boy==3.2.0
 faker==8.9.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if sys.argv[-1] == 'tag':
 
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
-requirements = open('requirements.txt').readlines()
+requirements = open('./requirements.txt').readlines()
 
 setup(
     name='django-admin-fast-search',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if sys.argv[-1] == 'tag':
 
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
-requirements = open('./requirements.txt').readlines()
+requirements = open('requirements.txt').readlines()
 
 setup(
     name='django-admin-fast-search',

--- a/tests/test_app/apps.py
+++ b/tests/test_app/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class TestAppConfig(AppConfig):
-    name = 'test_app'
+    name = 'tests.test_app'

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,19 @@
 [tox]
 envlist =
-    {py36,py37}-django-21
+    {py36,py37}-django-22
+    {py36,py37}-django-30
+    {py36,py37}-django-31
+    {py36,py37}-django-32
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/django_admin_fast_search
 commands = coverage run --source django_admin_fast_search runtests.py
 deps =
-    django-21: Django>=2.1,<2.2
+    django-22: Django>=2.2,<2.3
+    django-30: Django>=3.0,<3.1
+    django-31: Django>=3.1,<3.2
+    django-32: Django>=3.2,<3.3
     -r{toxinidir}/requirements_test.txt
 basepython =
     py37: python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -16,5 +16,6 @@ deps =
     django-32: Django>=3.2,<3.3
     -r{toxinidir}/requirements_test.txt
 basepython =
+    py38: python3.8
     py37: python3.7
     py36: python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    {py36,py37}-django-22
-    {py36,py37}-django-30
-    {py36,py37}-django-31
-    {py36,py37}-django-32
+    {py36,py37,py38}-django-22
+    {py36,py37,py38}-django-30
+    {py36,py37,py38}-django-31
+    {py36,py37,py38}-django-32
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py36,py37,py38}-django-21
+    {py36,py37}-django-21
 
 [testenv]
 setenv =
@@ -10,6 +10,5 @@ deps =
     django-21: Django>=2.1,<2.2
     -r{toxinidir}/requirements_test.txt
 basepython =
-    py38: python3.8
     py37: python3.7
     py36: python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py35,py36,py37}-django-21
+    {py36,py37,py38}-django-21
 
 [testenv]
 setenv =
@@ -10,7 +10,6 @@ deps =
     django-21: Django>=2.1,<2.2
     -r{toxinidir}/requirements_test.txt
 basepython =
+    py38: python3.8
     py37: python3.7
     py36: python3.6
-    py35: python3.5
-    py27: python2.7


### PR DESCRIPTION
Set up CircleCI to run tests against 12 Python/Django combinations - Python 3.6, 3.7 and 3.8 with Django 2.2, 3.0, 3.1 and 3.2. 

