### PR TITLE
remove search bar

### DIFF
--- a/django_admin_fast_search/templates/admin/custom_change_list.html
+++ b/django_admin_fast_search/templates/admin/custom_change_list.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load admin_list %}
 
+{% block search %}{% endblock %}
+
 {% block filters %}
   {% if cl.has_filters %}
     <div id="changelist-filter">


### PR DESCRIPTION
Remove the original search bar
- This change will remove the bar from any pages that use the FastSearch tool.