### PR TITLE
Make fulltext index query more specific

### DIFF
--- a/django_admin_fast_search/admin.py
+++ b/django_admin_fast_search/admin.py
@@ -43,6 +43,7 @@ def generic_filter_factory(filter_type):
     """
     Factory to generate GenericFilter classes. This helps us generate multiple independent copies of this class
     """
+
     class GenericExactFilter(admin.SimpleListFilter):
         title = None
         parameter_name = None
@@ -64,7 +65,6 @@ def generic_filter_factory(filter_type):
 
         template = "admin/custom_search_field.html"
 
-
         def lookups(self, request, model_admin):
             return (self.parameter_name, self.parameter_name),
 
@@ -80,13 +80,14 @@ def generic_filter_factory(filter_type):
 
         template = "admin/custom_search_field.html"
 
-
         def lookups(self, request, model_admin):
             return (self.parameter_name, self.parameter_name),
 
         def queryset(self, request, queryset):
             if self.value():
-                kwargs = {"{}__search".format(self.parameter_name): f"*{self.value()}*"}
+                terms = self.value().strip().split(" ")
+                query = " ".join(["+" + term for term in terms])
+                kwargs = {"{}__search".format(self.parameter_name): f"{query}"}
                 return queryset.filter(**kwargs)
             return queryset
 

--- a/django_admin_fast_search/admin.py
+++ b/django_admin_fast_search/admin.py
@@ -87,7 +87,7 @@ def generic_filter_factory(filter_type):
             if self.value():
                 terms = self.value().strip().split(" ")
                 query = " ".join(["+" + term for term in terms])
-                kwargs = {"{}__search".format(self.parameter_name): f"{query}"}
+                kwargs = {f"{self.parameter_name}__search": f"{query}"}
                 return queryset.filter(**kwargs)
             return queryset
 


### PR DESCRIPTION
The query now would look like 
`SELECT * FROM backend_userprofile WHERE MATCH(NAME) AGAINST('+shaela +mitchell' IN BOOLEAN MODE);`

The `+` means that the word _has_ to be present unlike earlier where it was optional. This means that results like `Shaela Lecompte` will not be found.

The original code was not wrong, it was just getting too many results (even if the prefix of one word matched) and we had the default sort on ID which would mess up the relevance sort. This change takes this search implementation closer (in terms of results) to the original query.

Asana Task https://app.asana.com/0/1133559545400194/1200884392597227