### PR TITLE
Remove mulitple consecutive space in query value

### DIFF
--- a/django_admin_fast_search/admin.py
+++ b/django_admin_fast_search/admin.py
@@ -86,7 +86,7 @@ def generic_filter_factory(filter_type):
         def queryset(self, request, queryset):
             if self.value():
                 terms = self.value().strip().split(" ")
-                query = " ".join(["+" + term for term in terms])
+                query = " ".join(["+" + term for term in terms if term.isalnum()])
                 kwargs = {f"{self.parameter_name}__search": f"{query}"}
                 return queryset.filter(**kwargs)
             return queryset

--- a/django_admin_fast_search/admin.py
+++ b/django_admin_fast_search/admin.py
@@ -86,7 +86,7 @@ def generic_filter_factory(filter_type):
         def queryset(self, request, queryset):
             if self.value():
                 terms = self.value().strip().split(" ")
-                query = " ".join(["+" + term for term in terms if term.isalnum()])
+                query = " ".join(["+" + term for term in terms if term])
                 kwargs = {f"{self.parameter_name}__search": f"{query}"}
                 return queryset.filter(**kwargs)
             return queryset


### PR DESCRIPTION
if there are multiple spaces in the value, split will create empty string (' '). before joining the terms check for empty string and avoid them