### PR TITLE
fix for full text search where words are seperated by spaces or special characters

### DIFF
--- a/django_admin_fast_search/admin.py
+++ b/django_admin_fast_search/admin.py
@@ -85,9 +85,10 @@ def generic_filter_factory(filter_type):
 
         def queryset(self, request, queryset):
             if self.value():
-                terms = self.value().strip().split(" ")
-                query = " ".join(["+" + term for term in terms if term])
-                kwargs = {f"{self.parameter_name}__search": f"{query}"}
+                # wrap the query argument in "" (double quotes),
+                # else words with spaces in between will be considered as 'A OR B' instead of 'A B'
+                query_arg = f'"{self.value().strip()}"'
+                kwargs = {f"{self.parameter_name}__search": f"{query_arg}"}
                 return queryset.filter(**kwargs)
             return queryset
 


### PR DESCRIPTION
**Summary**
The GenericSearchFilter uses full text search and current code make use of '+' operator to separate words before doing the query operation.  When special characters are added to the search string, the splitting and joining of words break the syntax of the query and raises errors. Instead of splitting the string we could enclose the search string in "" (double quotes). This searching requires only that matches contain exactly the same words as the phrase and in the same order. Special characters in the search will not raise any issue since we are not editing the string

Reference : https://dev.mysql.com/doc/refman/5.6/en/fulltext-boolean.html
(reference contains examples for different kind of searches available)

**Limitation**
When double quotes are used, mysql looks for **exact phase** in the in the **same order**. This could raise an issue when when we are searching for "steve rogers", But the value in the table is "rogers steve". 