### PR TITLE
Publish new version to PyPi only for a Tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,5 @@ workflows:
       - pypi_publish:
           context: PyPi
           filters:
-            branches:
-              only:
-                - master
             tags:
               only: /.+/


### PR DESCRIPTION
Currently we are running `invoke-release` CI for both `master` and `tags`. This PR changes that to only invoke `release` pipeline when a new `tag` is published